### PR TITLE
Reduce the depth by one by default

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -267,13 +267,14 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
         history += (*(stack-2)->contHist)[pc][to];
 
         reductions -= PvNode;
-        reductions -= history / 17500;
-        reductions = std::max(reductions, 1);
+
+        reductions -= history > 0 ? history / 5000 : history / 25000;
+        reductions = std::max(reductions, 0);
 
         if (depth > 2 && moveCount > 2) {
-            score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - reductions, si, stack+1);
+            score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 - reductions, si, stack+1);
 
-            if (!PvNode && score > alpha && reductions > 1)
+            if (!PvNode && score > alpha && reductions > 0)
                 score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1, si, stack+1);
 
             if (PvNode && score > alpha && score < beta)


### PR DESCRIPTION
Elo   | 0.76 +- 4.95 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=8MB
LLR   | 0.10 (-2.25, 2.89) [-4.00, 6.00]
Games | N: 10920 W: 3165 L: 3141 D: 4614
Penta | [319, 1294, 2192, 1354, 301]

Passes [-10.00, 0.00]
ELO: 0.764 +- 4.95 [-4.18, 5.71]
LLR: 6.27 [-10.0, 0.0] (-2.94, 2.94)
H1 Accepted

This was tested with non-regr bounds because the default depth reduction is something I fell like is useful for the future, after this commit a tune will follow after which simplyfing this back will be tried

bench 7202758