### PR TITLE
Fix compiling errors on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 Molybdenum
 build/
+.vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.24.2)
 project(Molybdenum)
 
 set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_CXX_COMPILER clang++)
+MATH(EXPR stack_size "4 * 1024 * 1024 * 1024") # 4 Gb
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--stack,${stack_size}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -march=native")

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,16 @@ DEFAULT_EXE = $(OBJ_DIR)/Molybdenum
 
 all: $(DEFAULT_EXE)
 
-CXXFLAGS = -static -Ofast
+CXXFLAGS = -static -Ofast -std=c++17
 CXXFLAGS += -Wall -Wextra -pedantic
 CXXFLAGS += -march=native
 CXXFLAGS += -Dmakefile
 
 LDFLAGS += -static -Ofast -march=native
+
+ifeq ($(OS),Windows_NT)
+	LDFLAGS += -Wl,/STACK:4294967296
+endif
 
 SOURCES := $(wildcard $(SRC_DIR)/*.cpp)
 OBJECTS := $(patsubst $(SRC_DIR)/%.cpp, $(OBJ_DIR)/%.o, $(SOURCES))

--- a/src/MagicBitboards.h
+++ b/src/MagicBitboards.h
@@ -70,7 +70,7 @@ struct MagicArrays {
 };
 
 template<Slider Type, bool MASK>
-constexpr u64 getSliderAttacks(int square, u64 blocker) {
+constexpr u64 getSliderAttacks(int square, u64 blocker = 0ULL) {
     constexpr bool ISROOK = Type == ROOK_S;
     u64 squareL = 1ULL << square;
     u64 stop = (((~lFIleOf(square) & edgeFiles) | (~lRankOf(square) & promotionRanks)) | blocker) & ~squareL;

--- a/src/Movegen.h
+++ b/src/Movegen.h
@@ -88,10 +88,10 @@ inline std::array<std::array<u64, 64>, 64> initMaskBB() {
             u64 blockers = squareL | square2L;
             u64 mask = 0;
 
-            if (getAttacks<BISHOP>(square, 0ULL) & square2L)
-                mask = getAttacks<BISHOP>(square, blockers) & getAttacks<BISHOP>(square2, blockers);
-            else if  (getAttacks<ROOK>(square, 0ULL) & square2L)
-                mask = getAttacks<ROOK>(square, blockers) & getAttacks<ROOK>(square2, blockers);
+            if (getSliderAttacks<BISHOP_S, false>(square) & square2L)
+                mask = getSliderAttacks<BISHOP_S, false>(square, blockers) & getSliderAttacks<BISHOP_S, false>(square2, blockers);
+            else if  (getSliderAttacks<ROOK_S, false>(square) & square2L)
+                mask = getSliderAttacks<ROOK_S, false>(square, blockers) & getSliderAttacks<ROOK_S, false>(square2, blockers);
 
             mask |= square2L;
 
@@ -110,10 +110,10 @@ inline std::array<std::array<u64, 64>, 64> initExtendedMaskBB() {
             u64 square2L = 1ULL << square2;
             u64 mask = 0;
 
-            if (getAttacks<BISHOP>(square, 0ULL) & square2L)
-                mask = getAttacks<BISHOP>(square) & getAttacks<BISHOP>(square2);
-            else if  (getAttacks<ROOK>(square, 0ULL) & square2L)
-                mask = getAttacks<ROOK>(square) & getAttacks<ROOK>(square2);
+            if (getSliderAttacks<BISHOP_S, false>(square) & square2L)
+                mask = getSliderAttacks<BISHOP_S, false>(square) & getSliderAttacks<BISHOP_S, false>(square2);
+            else if  (getSliderAttacks<ROOK_S, false>(square) & square2L)
+                mask = getSliderAttacks<ROOK_S, false>(square) & getSliderAttacks<ROOK_S, false>(square2);
 
 
             masksBB[square][square2] = mask;

--- a/src/incbin/incbin.h
+++ b/src/incbin/incbin.h
@@ -124,7 +124,7 @@
 /**
  * @brief Optionally override the linker section into which size and data is
  * emitted.
- *
+ * 
  * @warning If you use this facility, you might have to deal with
  * platform-specific linker output section naming on your own.
  */
@@ -151,7 +151,7 @@
  *
  * @warning If you use this facility, you might have to deal with
  * platform-specific linker output section naming on your own.
- *
+ * 
  * @note This is useful for Harvard architectures where program memory cannot
  * be directly read from the program without special instructions. With this you
  * can chose to put the size variable in RAM rather than ROM.
@@ -190,6 +190,10 @@
 #    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
 #  elif defined(__MINGW32__) || defined(__MINGW64__)
 /* Mingw doesn't support this directive either */
+#    define INCBIN_TYPE(NAME)
+#  elif defined(_WIN32)
+// CIEKCE: this just doesn't work on windows at all
+// (This update version of the file is taken from sp, it contained the comment above this is why this is here)
 #    define INCBIN_TYPE(NAME)
 #  else
 /* It's safe to use `@' on other architectures */
@@ -305,11 +309,11 @@
  * // extern const unsigned char *const <prefix>Foo<end>;
  * // extern const unsigned int <prefix>Foo<size>;
  * @endcode
- *
+ * 
  * You may specify a custom optional data type as well as the first argument.
  * @code
  * INCBIN_EXTERN(custom_type, Foo);
- *
+ * 
  * // Now you have the following symbols:
  * // extern const custom_type <prefix>Foo<data>[];
  * // extern const custom_type *const <prefix>Foo<end>;
@@ -378,7 +382,7 @@
  * // const unsigned char *const <prefix>Icon<end>;
  * // const unsigned int <prefix>Icon<size>;
  * @endcode
- *
+ * 
  * You may specify a custom optional data type as well as the first argument.
  * These macros are specialized by arity.
  * @code
@@ -436,7 +440,7 @@
 
 /**
  * @brief Include a textual file into the current translation unit.
- *
+ * 
  * This behaves the same as INCBIN except it produces char compatible arrays
  * and implicitly adds a null-terminator byte, thus the size of data included
  * by this is one byte larger than that of INCBIN.

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -2,9 +2,21 @@
 #include "Constants.h"
 #include "BitStuff.h"
 #include "Utility.h"
-#include "incbin/incbin.h"
 #include <cstring>
 #include <fstream>
+
+#ifdef _MSC_VER
+#define _MSC_VER_PUSHED
+#pragma push_macro("_MSC_VER")
+#undef _MSC_VER
+#endif
+
+#include "incbin/incbin.h"
+
+#ifdef _MSC_VER_PUSHED
+#pragma pop_macro("_MSC_VER")
+#undef _MSC_VER_PUSHED
+#endif
 
 #ifdef makefile
 #define defaultNetPath "src/Nets/ne3s23p6.nnue"
@@ -14,12 +26,15 @@
 
 
 INCBIN(network, defaultNetPath);
-const Net defaultNet = *reinterpret_cast<const Net*>(gnetworkData);
+const Weights defaultWeights = *reinterpret_cast<const Weights*>(gnetworkData);
 
 Net net;
 
 void loadDefaultNet() {
-    net = defaultNet;
+    net.weights0 = defaultWeights.weights0;
+    net.weights1 = defaultWeights.weights1;
+    net.bias0 = defaultWeights.bias0;
+    net.bias1 = defaultWeights.bias1;
 }
 
 void readNetwork(const std::string &filename) {

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -18,6 +18,13 @@ static const int OUTPUT_SIZE = 1;
 static const int NET_SIZE = 3;
 static const std::array<int, NET_SIZE> LAYER_SIZE = {INPUT_SIZE, L1_SIZE, OUTPUT_SIZE};
 
+struct Weights {
+    std::array<int16_t , L1_SIZE * INPUT_SIZE> weights0{};
+    std::array<int16_t, L1_SIZE> bias0{};
+    std::array<int16_t, L1_SIZE * OUTPUT_SIZE * 2> weights1{};
+    std::array<int16_t, OUTPUT_SIZE> bias1{};
+};
+
 struct Net {
     std::array<int16_t , L1_SIZE * INPUT_SIZE> weights0{};
     std::array<int16_t, L1_SIZE> bias0{};


### PR DESCRIPTION
The undef MSC_VER hack as well as the updatet incbin.h file are taken from Stormphrax, the other stuff was mostly fixing bad code that somehow compiled on linux 
bench 6015111