### PR TITLE
If a move failed singular search high, sort it right after the ttMove

### DIFF
--- a/src/Movepicker.h
+++ b/src/Movepicker.h
@@ -30,11 +30,13 @@ class Movepicker {
         PieceToHist *contHist1{};
         PieceToHist *contHist2{};
         Move ttMove = NO_MOVE;
+        Move prioMove = NO_MOVE;
         MoveList ml{};
         Position *pos;
         ScoredMove *currentMove = nullptr;
         ScoredMove *endMoveList = nullptr;
         bool scored = false;
+        bool searchedPrio = true;
 
     public:
         Movepicker(Position *p, Move ttm, 
@@ -120,13 +122,25 @@ class Movepicker {
         }
 
         inline Move pickMove() {
+
+            if (!searchedPrio) {
+                searchedPrio = true;
+                return prioMove;
+            }
+
             if (!scored && (scored = true))
                 return scoreMoves();
 
             if (currentMove == endMoveList)
                 return NO_MOVE;
 
-            return sortNext();
+            Move next = sortNext();
+            return (next == prioMove) ? sortNext() : next; 
+        }
+
+        inline void setPrioMove(Move pm) {
+            prioMove = pm;
+            searchedPrio = false;
         }
         
 };

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -236,7 +236,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
                                             &*(stack-2)->contHist, checkers);
     while ((currentMove = mp.pickMove())) {
     
-    if (currentMove == excluded)
+        if (currentMove == excluded)
             continue;
 
         int  from    = extract<FROM>(currentMove);
@@ -272,7 +272,6 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             && ttHit
             && currentMove == ttMove
             && ttBound != UPPER
-            //&& ttScore >= beta
             && ttDepth >= depth - 3
             && !excluded) {
             
@@ -280,11 +279,16 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             int singBeta  = ttScore - 25; 
 
             stack->excluded = ttMove;
+            stack->currMove = NO_MOVE;
             score = search<nt>(singBeta - 1, singBeta, pos, singDepth, si, stack);
             stack->excluded = NO_MOVE;
 
             if (score < singBeta)
                 extensions = 1;
+
+            if (   score > singBeta
+                && stack->currMove) 
+                mp.setPrioMove(stack->currMove);
         }
 
         u64 prefetchKey = key;


### PR DESCRIPTION
Elo   | 6.88 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8030 W: 2008 L: 1849 D: 4173
Penta | [126, 896, 1843, 993, 157]
http://aytchell.eu.pythonanywhere.com/test/90/

bench 7499086