### PR TITLE
Probe the TT in qsearch and cut-off arcodingly

### DIFF
--- a/src/searchUtil.h
+++ b/src/searchUtil.h
@@ -17,6 +17,18 @@ using ContHist = std::array<std::array<PieceToHist, 64>, 13>;
 
 const int histLimits = 2 << 13;
 
+inline void prefetchTTEntry(Position &pos, int pc, int from, int to, bool capture) {
+    u64 prefetchKey = pos.key();
+    updateKey(pc, from, prefetchKey);
+    updateKey(pc, to, prefetchKey);
+    updateKey(prefetchKey);
+
+    if (capture)
+        updateKey(pos.pieceOn(to), to, prefetchKey);
+
+    __builtin_prefetch(TT.probe(prefetchKey));
+}
+
 inline void updateHistory(FromToHist &history, PieceToHist &contHist, PieceToHist  &contHist2, Move bestMove, Stack<Move> &movesToUpdate, int depth, Position &pos, const bool updateCont, const bool updateCont2) {
     int from = extract<FROM>(bestMove);
     int to   = extract<TO  >(bestMove);


### PR DESCRIPTION
Elo   | 18.25 +- 9.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2648 W: 718 L: 579 D: 1351
Penta | [31, 300, 553, 379, 61]
http://aytchell.eu.pythonanywhere.com/test/97/

bench 7287389