### PR TITLE
If the ttMove is a cpature use it for ordering in qs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -390,6 +390,7 @@ int qsearch(int alpha, int beta, Position &pos, SearchInfo &si, SearchStack *sta
 
     int ttScore = 0, ttBound = UPPER;
     bool ttHit = false;
+    Move ttMove = NO_MOVE;
     u64 key = pos.key();
     TTEntry* tte = TT.probe(key);
 
@@ -397,6 +398,9 @@ int qsearch(int alpha, int beta, Position &pos, SearchInfo &si, SearchStack *sta
         ttBound = tte->bound;
         ttScore = tte->score;
         ttHit   = true;
+
+        if (tte->move && pos.pieceOn(extract<TO>(tte->move)) != NO_PIECE)
+            ttMove = tte->move;
 
         if (ttScore > MAXMATE)
             ttScore -= stack->plysInSearch;
@@ -415,7 +419,7 @@ int qsearch(int alpha, int beta, Position &pos, SearchInfo &si, SearchStack *sta
     if (bestScore >= beta)
         return bestScore;
 
-    Movepicker mp = Movepicker<true>(&pos, NO_MOVE);
+    Movepicker mp = Movepicker<true>(&pos, ttMove);
 
     while ((currentMove = mp.pickMove())) {
         int from     = extract<FROM>(currentMove);


### PR DESCRIPTION
Elo   | 16.94 +- 8.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.10 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3058 W: 831 L: 682 D: 1545
Penta | [44, 323, 678, 408, 76]
http://aytchell.eu.pythonanywhere.com/test/100/

bench 6594679