### PR TITLE
If the new entry has the same key as the old one, prefer the one with…

### DIFF
--- a/src/Transpositiontable.cpp
+++ b/src/Transpositiontable.cpp
@@ -33,6 +33,10 @@ TTEntry *TranspositionTable::probe(u64 key) {
 }
 
 void TranspositionTable::save(TTEntry *tte, u64 key, int score, TTBound bound, Move move, int depth, int plysInSearch) {
+    if (   tte->key == key
+        && depth + bound < tte->depth + tte->bound - 3)
+        return;
+
     tte->key = key;
     tte->move = move;
     tte->bound = bound;

--- a/src/Transpositiontable.h
+++ b/src/Transpositiontable.h
@@ -7,7 +7,7 @@
 #include "Move.h"
 
 enum TTBound {
-    LOWER, UPPER, EXACT
+    UPPER, LOWER, EXACT
 };
 
 struct TTEntry {


### PR DESCRIPTION
… the higher depth, valuing LOWER and EXACT bounds more than UPPER bounds and including a depth - 3 to generally prefer new entrys (due to possibly more accurate scores at lower depths e.g. singExt or ttCutoffs from different higher entries in search)

Elo   | 12.65 +- 7.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3820 W: 973 L: 834 D: 2013
Penta | [46, 424, 853, 519, 68]
http://aytchell.eu.pythonanywhere.com/test/111/

bench 6706876