### PR TITLE
Store TTBound and depth as 8 bit integer saving a few bytes of the tt…

### DIFF
--- a/src/Transpositiontable.h
+++ b/src/Transpositiontable.h
@@ -6,13 +6,13 @@
 #include "MagicBitboards.h"
 #include "Move.h"
 
-enum TTBound {
+enum TTBound : uint8_t {
     UPPER, LOWER, EXACT
 };
 
 struct TTEntry {
     int score;
-    int depth;
+    uint8_t depth;
     TTBound bound;
     Move move;
     u64 key;


### PR DESCRIPTION
…Entry size

Elo   | 13.10 +- 7.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3688 W: 962 L: 823 D: 1903
Penta | [49, 398, 835, 489, 73]
http://aytchell.eu.pythonanywhere.com/test/115/

bench 7538718