### PR TITLE
Fix oversight that only applied tuned hist limits to bonuses and kept…

### DIFF
--- a/src/searchUtil.h
+++ b/src/searchUtil.h
@@ -48,11 +48,11 @@ inline void updateHistory(FromToHist &history, PieceToHist &contHist, PieceToHis
         to   = extract<TO  >(move);
         pc   = pos.pieceOn(from);
 
-        history[from][to] += malus - history [from][to] * abs(malus) / 65536;
+        history[from][to] += malus - history [from][to] * abs(malus) / histLimits;
         if (updateCont)
-            contHist[pc][to] += malus - contHist[pc][to] * abs(malus) / 65536;
+            contHist[pc][to] += malus - contHist[pc][to] * abs(malus) / histLimits;
         if (updateCont2)
-            contHist2[pc][to] += malus - contHist2[pc][to] * abs(malus) / 65536;
+            contHist2[pc][to] += malus - contHist2[pc][to] * abs(malus) / histLimits;
     }
 }
 


### PR DESCRIPTION
… the old limit for mala

Elo   | 4.56 +- 3.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14084 W: 3498 L: 3313 D: 7273
Penta | [205, 1692, 3086, 1831, 228]
http://aytchell.eu.pythonanywhere.com/test/118/

bench 6642492