### PR TITLE
Deduct fractional depths from history pruning margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -246,7 +246,9 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
         bool capture = pos.isCapture(currentMove);
         Piece pc = pos.pieceOn(from);
 
-        int reductions = lmrReduction(depth, moveCount, improving);
+        double red = lmrReduction(depth, moveCount, improving);
+        int reductions = int(red);
+        int quarterRed = (red - reductions) * 4;
         int expectedDepth = std::max(depth - reductions, 1);
         int history = (*(stack-1)->contHist)[pc][to] + mainHistory[pos.sideToMove][from][to];
 
@@ -267,7 +269,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             && bestScore > -MAXMATE
             && !capture
             && depth <= 5
-            && history < -6009 * expectedDepth)
+            && history < -6009 * expectedDepth - (-6009 * quarterRed) / 4)
             continue;
 
         if (   depth >= 8

--- a/src/search.h
+++ b/src/search.h
@@ -41,15 +41,16 @@ void clearHistory();
 inline std::array<double, 256> initReductions() {
     std::array<double, 256> R{};
 
-    for (int i = 0; i < 256; i++) R[i] = std::log(i);
+    for (int i = 1; i < 256; i++) R[i] = std::log(i);
+    R[0] = 0;
 
     return R;
 }
 
 static std::array<double, 256> Log = initReductions();
 
-inline int lmrReduction(int depth, int movecount, bool improving) {
-    return int(0.66 + !improving * 0.49 + Log[depth] * Log[movecount] / 2.02);
+inline double lmrReduction(int depth, int movecount, bool improving) {
+    return 0.66 + !improving * 0.49 + Log[depth] * Log[movecount] / 2.02;
 }
 
 inline int mateInPlies(int score) {


### PR DESCRIPTION
In history pruning deduct fractional reductions with one fourth precision from the total margin

Passed STC:
Elo   | 8.90 +- 6.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5738 W: 1472 L: 1325 D: 2941
Penta | [65, 679, 1282, 730, 113]
http://aytchell.eu.pythonanywhere.com/test/143/

bench 6606439