### PR TITLE
Subtract quarter reductions of previous ply from mcp depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -139,6 +139,8 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
     bool exact = false, check = checkers, ttHit = false, improving, whatAreYouDoing;
     Stack<Move> historyUpdates;
 
+    stack->quarterRed = 0;
+
     excluded = stack->excluded;
     (stack+1)->excluded = NO_MOVE;
 
@@ -248,14 +250,14 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
 
         double red = lmrReduction(depth, moveCount, improving);
         int reductions = int(red);
-        int quarterRed = (red - reductions) * 4;
+        stack->quarterRed = (red - reductions) * 4;
         int expectedDepth = std::max(depth - reductions, 1);
         int history = (*(stack-1)->contHist)[pc][to] + mainHistory[pos.sideToMove][from][to];
 
         if (   !capture
             && bestScore > -MAXMATE
             && depth <= 4
-            && moveCount > 11 * depth)
+            && moveCount > 11 * depth - ((stack-1)->quarterRed * 11) / 4)
             continue;
 
         if (   !PvNode
@@ -269,7 +271,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             && bestScore > -MAXMATE
             && !capture
             && depth <= 5
-            && history < -6009 * expectedDepth - (-6009 * quarterRed) / 4)
+            && history < -6009 * expectedDepth - (-6009 * stack->quarterRed) / 4)
             continue;
 
         if (   depth >= 8

--- a/src/search.h
+++ b/src/search.h
@@ -25,6 +25,7 @@ struct SearchInfo {
 struct SearchStack {
     int plysInSearch = 0;
     int staticEval = INFINITE;
+    int quarterRed = 0;
     Move currMove = 0;
     Move excluded = NO_MOVE;
     PieceToHist *contHist = nullptr;


### PR DESCRIPTION
Passed STC:
Elo   | 6.26 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8604 W: 2152 L: 1997 D: 4455
Penta | [101, 986, 1983, 1121, 111]
http://aytchell.eu.pythonanywhere.com/test/152/

bench 5751949