### PR TITLE
Also apply fractional depth to fp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -264,7 +264,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             && !capture
             && bestScore > -MAXMATE
             && depth <= 7
-            && stack->staticEval + 188 + 203 * expectedDepth <= alpha)
+            && stack->staticEval + 188 + 203 * expectedDepth  - (203 * stack->quarterRed) / 4 <= alpha)
             continue;
 
         if (   !PvNode


### PR DESCRIPTION
Passed STC:
Elo   | 3.47 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21510 W: 5288 L: 5073 D: 11149
Penta | [322, 2518, 4867, 2719, 329]
http://aytchell.eu.pythonanywhere.com/test/159/

bench explosion seems to be caused by one specific position, where search jumps to 10m nodes at d13

bench 19148590