### PR TITLE
Adjust returned score based on ttScore

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -374,6 +374,11 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
     if (bestScore == -INFINITE)
         return excluded ? alpha : checkers ? (-MATE + stack->plysInSearch) : DRAW;
 
+    if (   !PvNode
+        && ttDepth > depth
+        && ttBound == (ttScore >= bestScore ? LOWER : UPPER))
+        bestScore = ttScore;
+
     if (!excluded)
         TT.save(tte, key, bestScore, exact ? EXACT : UPPER, bestMove, depth, stack->plysInSearch);
 


### PR DESCRIPTION
If we hit a higher depth entry that suggests the current bestScore is inaccurate, set it to ttScore

Elo   | 4.20 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15640 W: 3856 L: 3667 D: 8117
Penta | [216, 1816, 3615, 1909, 264]
http://aytchell.eu.pythonanywhere.com/test/222/

bench 7290550