### PR TITLE
Adjust Se margin based on root movecount

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -288,7 +288,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             && !excluded) {
             
             int singDepth = depth / 2;
-            int singBeta  = ttScore - 18; 
+            int singBeta  = ttScore - 12 + std::min(si.rootMoveCount * 2, 12); 
 
             stack->excluded = ttMove;
             stack->currMove = NO_MOVE;
@@ -314,6 +314,9 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
 
         si.nodeCount++;
         moveCount++;
+
+        if constexpr (ROOT)
+            si.rootMoveCount = moveCount;
 
         history += (*(stack-2)->contHist)[pc][to];
 

--- a/src/search.h
+++ b/src/search.h
@@ -20,6 +20,7 @@ struct SearchInfo {
     bool stop = false;
     Move bestRootMove = 0;
     searchTime st;
+    int rootMoveCount = 0;
 };
 
 struct SearchStack {


### PR DESCRIPTION
idea being that trees resulting from later root moves are less likely to produce a good line therfore are less valuable to extend

Passed STC:
Elo   | 3.71 +- 3.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19178 W: 4759 L: 4554 D: 9865
Penta | [259, 2302, 4285, 2461, 282]
http://aytchell.eu.pythonanywhere.com/test/231/

Passed MTC:
Elo   | 13.54 +- 8.33 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3158 W: 809 L: 686 D: 1663
Penta | [15, 337, 767, 430, 30]
http://aytchell.eu.pythonanywhere.com/test/241/

Passed LTC:
Elo   | 14.79 +- 8.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2986 W: 738 L: 611 D: 1637
Penta | [21, 318, 705, 411, 38]
http://aytchell.eu.pythonanywhere.com/test/242/

bench 11883939