### PR TITLE
Dont singular extend at root

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -281,6 +281,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             continue;
 
         if (   depth >= 8
+            && !ROOT
             && ttHit
             && currentMove == ttMove
             && ttBound != UPPER


### PR DESCRIPTION
Currently se extends the whole node, which means extending at root just leads to skipping one depth which does not seem desirable

Passed STC:
Elo   | 12.00 +- 7.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4114 W: 1063 L: 921 D: 2130
Penta | [55, 466, 885, 584, 67]
http://aytchell.eu.pythonanywhere.com/test/243/

bench 6415046