### PR TITLE
MCP more when not improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -263,7 +263,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
         if (   !capture
             && bestScore > -MAXMATE
             && depth <= 4
-            && moveCount > 11 * depth - ((stack-1)->quarterRed * 10) / 4)
+            && moveCount > (3 + improving) * (11 * depth - ((stack-1)->quarterRed * 10) / 4) / 4)
             continue;
 
         if (   !PvNode


### PR DESCRIPTION
Elo   | 6.25 +- 5.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8842 W: 2192 L: 2033 D: 4617
Penta | [124, 1017, 1982, 1172, 126]
http://aytchell.eu.pythonanywhere.com/test/244/

bench 6732456