### PR TITLE
Dont singular extend all moves in a node if singularsearch failed low

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -254,6 +254,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
                                             &*(stack-1)->contHist, 
                                             &*(stack-2)->contHist, checkers);
     while ((currentMove = mp.pickMove())) {
+        extensions = depth + moveCount <= 13 ? extensions : 0;
     
         if (currentMove == excluded)
             continue;


### PR DESCRIPTION
Initially this was an oversight in the intruduction of singular extensions, now limit it to only extend the first few moves and only if the depth is low,

Passed STC:
Elo   | 5.50 +- 4.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9984 W: 2477 L: 2319 D: 5188
Penta | [87, 1200, 2309, 1260, 136]
http://aytchell.eu.pythonanywhere.com/test/391/

This may regress at longer timecontrols, I just dont have the ressources to test it right now

bench 4732467