### PR TITLE
Update killers in a different way at root

### DIFF
--- a/src/Movepicker.h
+++ b/src/Movepicker.h
@@ -36,6 +36,7 @@ class Movepicker {
         ScoredMove *currentMove = nullptr;
         ScoredMove *endMoveList = nullptr;
         bool scored = false;
+        bool root   = false;
         bool searchedPrio = true;
 
     public:
@@ -44,14 +45,17 @@ class Movepicker {
                       FromToHist  *main  = &emptyMain, 
                       PieceToHist *cont1 = &emptyCont, 
                       PieceToHist *cont2 = &emptyCont, 
-                      u64 checkers = 0ULL) 
+                      u64 checkers = 0ULL,
+                      bool r       = false) 
         {
             ttMove = ttm; 
             killers = k; 
             mainHist = main; 
             contHist1 = cont1; 
             contHist2 = cont2;
-            pos = p;
+            pos  = p;
+            root = r;
+
 
             generateMoves<qsearch>(*pos, ml, checkers);
 
@@ -79,9 +83,9 @@ class Movepicker {
                 if (move == ttMove)
                     *score = 10000000;
                 else if (move == killers[0][0])
-                    *score = 900000;
+                    *score = 900000 + 10 * root;
                 else if (move == killers[0][1])
-                    *score = 800000;
+                    *score = 800000 + 10 * root;
 
                 *score += mainHist [0][from][to];
                 *score += contHist1[0][pc][to];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -252,7 +252,7 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
                                             &killers[stack->plysInSearch], 
                                             &mainHistory[pos.sideToMove], 
                                             &*(stack-1)->contHist, 
-                                            &*(stack-2)->contHist, checkers);
+                                            &*(stack-2)->contHist, checkers, ROOT);
     while ((currentMove = mp.pickMove())) {
         extensions = depth + moveCount <= 13 ? extensions : 0;
     
@@ -365,15 +365,16 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
                 alpha = score;
                 exact = true;
 
-                if (score >= beta) {
-                    if (!pos.isCapture(bestMove)) {
-                        updateHistory(mainHistory[pos.sideToMove], *(stack-1)->contHist, *(stack-2)->contHist, bestMove, historyUpdates, depth, pos, (stack-1)->currMove && (stack-1)->currMove != NULL_MOVE, (stack-2)->currMove && (stack-2)->currMove != NULL_MOVE);
-
-                        if (bestMove != killers[stack->plysInSearch][0]) {
-                            killers[stack->plysInSearch][1] = killers[stack->plysInSearch][0];
-                            killers[stack->plysInSearch][0] = bestMove;
-                        }
+                if (ROOT || (score >= beta && !pos.isCapture(bestMove))) {
+                    if (bestMove != killers[stack->plysInSearch][0]) {
+                        killers[stack->plysInSearch][1] = killers[stack->plysInSearch][0];
+                        killers[stack->plysInSearch][0] = bestMove;
                     }
+                }
+
+                if (score >= beta) {
+                    if (!pos.isCapture(bestMove))
+                        updateHistory(mainHistory[pos.sideToMove], *(stack-1)->contHist, *(stack-2)->contHist, bestMove, historyUpdates, depth, pos, (stack-1)->currMove && (stack-1)->currMove != NULL_MOVE, (stack-2)->currMove && (stack-2)->currMove != NULL_MOVE);
 
                     TT.save(tte, key, bestScore, LOWER, bestMove, depth, stack->plysInSearch);
                     return bestScore;


### PR DESCRIPTION
Allow captures as killers, update them on beating alpha not beta and search them before captures

Passed STC:
Elo   | 4.21 +- 3.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14594 W: 3529 L: 3352 D: 7713
Penta | [155, 1700, 3442, 1813, 187]
http://aytchell.eu.pythonanywhere.com/test/388/

bench 6257966