### PR TITLE
Prefetch the TTEntry after a nullmove

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -233,6 +233,10 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
         && stack->staticEval >= beta
         && beta > -MAXMATE) {
 
+        u64 prefetchKey = key;
+        updateKey(prefetchKey);
+        __builtin_prefetch(TT.probe(prefetchKey));
+
         int reduction = std::min(depth, (4 + (stack->staticEval >= beta + 290) + (depth > 6)));
 
         pos.makeNullMove();


### PR DESCRIPTION
Passed VSTC:
Elo   | 3.34 +- 3.08 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=4MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 25616 W: 6869 L: 6623 D: 12124
Penta | [498, 2922, 5750, 3112, 526]
http://aytchell.eu.pythonanywhere.com/test/399/

bench 4881740