### PR TITLE
Research PVNode LMR fail highs with full depth but zero window first

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -346,6 +346,9 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             if (!PvNode && score > alpha && reductions > 0)
                 score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 + extensions, si, stack+1);
 
+            if (PvNode && score > alpha && reductions > 0)
+                score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 + extensions, si, stack+1);
+
             if (PvNode && score > alpha && score < beta)
                 score = -search<PVNode>(-beta, -alpha, pos, depth - 1 + extensions, si, stack+1);
         } else {


### PR DESCRIPTION
Before this, if a move scored above beta from the reduced search, the node would fail high without researching the move at full depth

Passed STC:
Elo   | 6.11 +- 5.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8816 W: 2208 L: 2053 D: 4555
Penta | [94, 1038, 2009, 1153, 114]
http://aytchell.eu.pythonanywhere.com/test/400/

bench 4870687