### PR TITLE
Fix quantization of output bias

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -68,5 +68,5 @@ int calculate(Color c) {
          output += relu(net.accumulator[!c][n]) * net.weights1[n + L1_SIZE];
     }
 
-    return (output + net.bias1[0]) * 400 / 4161600;
+    return ((output / 255) + net.bias1[0]) * 400 / (64 * 255);
 }


### PR DESCRIPTION
The output bias is qunatized using QA * QB, so / (QA * QA * QB) is only applicalble to the output of the hidden layer and not the output neuron (SCReLU)

Passed STC:
Elo   | 9.43 +- 7.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3868 W: 981 L: 876 D: 2011
Penta | [48, 435, 881, 504, 66]
http://aytchell.eu.pythonanywhere.com/test/425/

bench 4940522