### PR TITLE
Dont evaluate before ttCutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -148,18 +148,12 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
 
     excluded = stack->excluded;
 
-    if (!excluded)
-        stack->staticEval = evaluate(pos);
-
     if (stack->plysInSearch > si.selDepth)
         si.selDepth = stack->plysInSearch;
     
     stack->plysInSearch = ROOT ? 0 : (stack-1)->plysInSearch + 1;
     stack->quarterRed   = 0;
     (stack+1)->excluded = NO_MOVE;
-
-    improving       = stack->staticEval > (stack-2)->staticEval;
-    whatAreYouDoing = stack->staticEval + (stack-1)->staticEval > 0;
 
     pvLength[stack->plysInSearch] = stack->plysInSearch;
 
@@ -216,6 +210,12 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
             || (ttBound == LOWER && ttScore >= beta)
             || (ttBound == UPPER && ttScore <= alpha)))
         return ttScore;
+
+    if (!excluded)
+        stack->staticEval = evaluate(pos);
+
+    improving       = stack->staticEval > (stack-2)->staticEval;
+    whatAreYouDoing = stack->staticEval + (stack-1)->staticEval > 0;
 
     if (   !PvNode
         && !check


### PR DESCRIPTION
Static eval is not needed this early, therfore not evaluating when a cutoff happens saves an evaluate call

Passed VSTC:
Elo   | 6.72 +- 5.34 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=4MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8434 W: 2276 L: 2113 D: 4045
Penta | [152, 925, 1922, 1044, 174]
http://aytchell.eu.pythonanywhere.com/test/427/

bench 4940522