### PR TITLE
Move eval divisor to where eval scale is applied

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -5,7 +5,7 @@
 #include "nnue.h"
 
 inline int evaluate(Position &pos) {
-    return calculate(pos.sideToMove) / 3;
+    return calculate(pos.sideToMove);
 }
 
 #endif //MOLYBDENUM_EVAL_H

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -68,5 +68,5 @@ int calculate(Color c) {
          output += relu(net.accumulator[!c][n]) * net.weights1[n + L1_SIZE];
     }
 
-    return ((output / 255) + net.bias1[0]) * 400 / (64 * 255);
+    return ((output / 255) + net.bias1[0]) * 133 / (64 * 255);
 }


### PR DESCRIPTION
Passed Non regr 25k fixed nodes

Elo   | 1.39 +- 4.04 (95%)
SPRT  | N=25000 Threads=1 Hash=8MB
LLR   | 3.06 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 16486 W: 4827 L: 4761 D: 6898
Penta | [526, 1940, 3248, 2000, 529]
http://aytchell.eu.pythonanywhere.com/test/457/

bench 4546084