### PR TITLE
Extend research if all prior moves were bad

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -343,8 +343,10 @@ int search(int alpha, int beta, Position &pos, int depth, SearchInfo &si, Search
         if (depth > 1 && moveCount > 2) {
             score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 - reductions + extensions, si, stack+1);
 
-            if (score > alpha && reductions > 0)
-                score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 + extensions, si, stack+1);
+            if (score > alpha && reductions > 0) {
+                bool nightmare = bestScore < alpha - 100 && moveCount > 3;
+                score = -search<NonPvNode>(-alpha - 1, -alpha, pos, depth - 1 + extensions + nightmare, si, stack+1);
+            }
 
             if (PvNode && score > alpha && score < beta)
                 score = -search<PVNode>(-beta, -alpha, pos, depth - 1 + extensions, si, stack+1);


### PR DESCRIPTION
This inspired by a message by https://github.com/tsoj talking about having a nightmare, were he thought he woke up, however it turned out he didnt. The nightmare in this this patch is the three first moves scoring well below alpha, we expect these moves to be the best, so if those all score badly, we dont necessarily expect to have a later move beat alpha an therefore induce a research. So if we do "wake up" by finding a move that does beat alpha, we check carefully that we did indeed wake up by extending the search, in order to avoid thinking we woke up and therfore return a fail high/ take this as a alpha beating score, if we did not wake up. Something to note is that this patch is similar to the doDepper idea, infact, a nightmare would almost always imply a doDeeper, however a doDeeper does not imply a nightmare. This way seems more sensible to me, though this may well be just worse than doDeeper, I never tested it against each other.

bench 5022919