### PR TITLE
Implement lazySMP

### DIFF
--- a/src/UCI.h
+++ b/src/UCI.h
@@ -6,6 +6,7 @@
 #include "search.h"
 #include "tune.h"
 #include "UCIOptions.h"
+#include "thread.h"
 
 #include <unordered_map>
 #include <vector>
@@ -14,9 +15,8 @@
 class UCI {
 
 private:
-    SearchState state;
-    Position    internalBoard;
-    UCIOptions  options;
+    Position   internalBoard;
+    UCIOptions options = UCIOptions(this);
     std::unordered_map<std::string, void(UCI::*)(const std::string&)> commands;
 
     const std::string name       = "Molybdenum";
@@ -28,6 +28,8 @@ private:
 #endif
 
 public:
+    ThreadPool threads;
+
     UCI() {
         internalBoard.net.loadDefaultNet();
         internalBoard.setBoard(defaultFEN);
@@ -36,6 +38,7 @@ public:
         commands["go"] = &UCI::go;
         commands["uci"] = &UCI::uci;
         commands["eval"] = &UCI::eval;
+        commands["stop"] = &UCI::stop;
         commands["bench"] = &UCI::bench;
         commands["isready"] = &UCI::isready;
         commands["goPerft"] = &UCI::goPerft;
@@ -45,7 +48,8 @@ public:
 
 
         options.init();
-        state.clearHistory();
+        threads.set(1);
+        threads.clear();
 
 #ifdef TUNE
         tuneOptions.init();
@@ -57,6 +61,7 @@ public:
     void go(const std::string &time);
     void uci(const std::string &args);
     void eval(const std::string &args);
+    void stop(const std::string &args);
     void bench(const std::string &args);
     void goPerft(const std::string &args);
     void isready(const std::string &args);

--- a/src/UCIOptions.cpp
+++ b/src/UCIOptions.cpp
@@ -1,6 +1,7 @@
 #include "UCIOptions.h"
 #include "Transpositiontable.h"
 #include "timemanagement.h"
+#include "UCI.h"
 
 bool UCIOptions::setOption(const std::string& name, int value) {
     UCIOptionSpin *option = findOptionSpin(name);
@@ -9,19 +10,29 @@ bool UCIOptions::setOption(const std::string& name, int value) {
         return false;
 
     if (value <= option->max && value >= option->min)
-        option->setter(value);
+        (*this.*(option->setter))(value);
     else
         std::cout << "Value " << value << " is not within bounds of option " << name << "\n";
 
     return true;
 }
 
-void foo([[maybe_unused]] int bar){}
+void UCIOptions::setHash(int val) {
+    resizeTT(val);
+}
+
+void UCIOptions::setThreads(int val) {
+    uci->threads.set(val);
+}
+
+void UCIOptions::setMoveOverhead(int val) {
+    setOverhead(val);
+}
 
 void UCIOptions::init() {
-    spinOptions.push(UCIOptionSpin("Hash", 1, 1024, 16, &resizeTT));
-    spinOptions.push(UCIOptionSpin("Threads", 1, 1, 1, &foo));
-    spinOptions.push(UCIOptionSpin("Move Overhead", 0, 2000, 10, &setOverhead));
+    spinOptions.push(UCIOptionSpin("Hash", 1, 1024, 16, &UCIOptions::setHash));
+    spinOptions.push(UCIOptionSpin("Threads", 1, 32, 1, &UCIOptions::setThreads));
+    spinOptions.push(UCIOptionSpin("Move Overhead", 0, 2000, 10, &UCIOptions::setMoveOverhead));
 }
 
 UCIOptionSpin *UCIOptions::findOptionSpin(const std::string& name) {

--- a/src/UCIOptions.h
+++ b/src/UCIOptions.h
@@ -6,9 +6,12 @@
 #include "string"
 #include "Utility.h"
 
+class UCI;
+class UCIOptions;
+
 class UCIOptionSpin {
     public:
-        explicit UCIOptionSpin(std::string name = "NONE", int min = 0, int max = 0, int dfault = 0, void (*setter)(int) = nullptr) {
+        explicit UCIOptionSpin(std::string name = "NONE", int min = 0, int max = 0, int dfault = 0, void (UCIOptions::*setter)(int) = nullptr) {
             this->name = std::move(name);
             this->min = min;
             this->max = max;
@@ -20,7 +23,7 @@ class UCIOptionSpin {
         int min;
         int max;
         int dfault;
-        void (*setter)(int);
+        void (UCIOptions::*setter)(int);
 };
 
 class UCIOptions {
@@ -29,9 +32,22 @@ class UCIOptions {
         virtual bool setOption(const std::string& name, int value);
         void printOptions();
 
+        UCIOptions(UCI* u) {
+            uci = u;
+        }
+
+        UCIOptions() {}
+
     protected:
         Stack<UCIOptionSpin> spinOptions;
         UCIOptionSpin* findOptionSpin(const std::string& name);
+
+    private:
+        UCI* uci;
+
+        void setHash(int val);
+        void setThreads(int val);
+        void setMoveOverhead(int val);
 };
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -1,0 +1,86 @@
+#include "thread.h"
+
+void Thread::start(Position &pos, SearchTime &st, int depth) {
+    state.thread = this;
+    thread = std::thread{[this, pos, st, depth]() mutable { state.startSearch(pos, st, depth); }};
+}
+
+void Thread::join() {
+    if (thread.joinable())
+        thread.join();
+}
+
+void Thread::stop() {
+    state.si.stop.store(true, std::memory_order_relaxed);
+}
+
+void Thread::clear() {
+    state.clearHistory();
+}
+
+void Thread::detach() {
+    thread.detach();
+}
+
+int Thread::id() const {
+    return threadId;
+}
+
+bool Thread::done() {
+    return !searching.load(std::memory_order_relaxed);
+}
+
+u64 Thread::nodes() {
+    return state.si.nodeCount.load(std::memory_order_relaxed);
+}
+
+void ThreadPool::start(Position &pos, SearchTime &st, int depth) {
+    // Before starting the threads set all of them to searching, to avoid the mainthread stopping search
+    // while other threads havent been started yet
+    for (auto &t : threads)
+        t.searching.store(true, std::memory_order_relaxed);
+
+    for (auto &t : threads)
+        t.start(pos, st, depth);
+}
+
+void ThreadPool::join() {
+    for (auto &t : threads)
+        t.join();
+}
+
+void ThreadPool::stop() {
+    for (auto &t : threads)
+        t.stop();
+}
+
+void ThreadPool::set(int count) {
+    join();
+    threads.clear();
+    int id = 0;
+
+    for (int i = 0; i < count; i++)
+        threads.push_back(Thread(this, id++));
+}
+
+void ThreadPool::clear() {
+    for (auto &t : threads)
+        t.clear();
+}
+
+u64 ThreadPool::nodes() {
+    u64 sum = 0;
+
+    for (auto &t : threads)
+        sum += t.nodes();
+
+    return sum;
+}
+
+bool ThreadPool::done() {
+    for (auto &t : threads)
+        if (!t.done())
+            return false;
+
+    return true;
+}

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,0 +1,60 @@
+#ifndef MOLYBDENUM_THREAD_H
+#define MOLYBDENUM_THREAD_H
+
+#include "search.h"
+
+#include <thread>
+#include <vector>
+#include <atomic>
+
+class ThreadPool;
+
+class Thread {
+    
+    std::thread thread;
+    int         threadId;
+
+public:
+    ThreadPool* threads;
+    std::atomic_bool searching;
+    SearchState state;
+
+    void start(Position &pos, SearchTime &st, int depth);
+    void join();
+    void stop();
+    void clear();
+    void detach();
+    bool done();
+    int id() const;
+    u64  nodes();
+
+    Thread(ThreadPool* t, int i) {
+        threadId     = i;
+        threads      = t;
+        searching.store(false);
+        state.clearHistory();
+    }
+
+    Thread(const Thread &t) {
+        threadId = t.id();
+        threads  = t.threads;
+        searching.store(false);
+        state.clearHistory();
+    }
+};
+
+class ThreadPool {
+    std::vector<Thread> threads;
+
+public:
+    void start(Position &pos, SearchTime &st, int depth);
+    void join();
+    void stop();
+    void set(int count);
+    void clear();
+    bool done();
+
+    u64 nodes();
+};
+
+#endif


### PR DESCRIPTION
Passed 2v1 thread STC:
Elo   | 82.15 +- 19.43 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=8MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 616 W: 223 L: 80 D: 313
Penta | [1, 38, 111, 133, 25]
http://aytchell.eu.pythonanywhere.com/test/485/

Non non drawn game pairs on 25k fixed nodes:
Elo   | -0.00 +- 10.04 (95%)
Conf  | N=25000 Threads=1 Hash=8MB
Games | N: 2564 W: 716 L: 716 D: 1132
Penta | [0, 0, 1282, 0, 0]
http://aytchell.eu.pythonanywhere.com/test/488/

Passed Non regr 1v1 thread STC:
Elo   | 13.06 +- 9.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 2662 W: 697 L: 597 D: 1368
Penta | [19, 258, 694, 324, 36]
http://aytchell.eu.pythonanywhere.com/test/484/

The good result is probably caused by a speedup, not sure where it comes from but it seems to be there:

Passed VSTC 1v1 threads:
Elo   | 28.17 +- 11.84 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=4MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1706 W: 507 L: 369 D: 830
Penta | [22, 144, 407, 234, 46]
http://aytchell.eu.pythonanywhere.com/test/489/

Passed Gainer STC:
Elo   | 12.17 +- 7.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3714 W: 935 L: 805 D: 1974
Penta | [23, 392, 934, 448, 60]
http://aytchell.eu.pythonanywhere.com/test/487/

bench 5022919