### PR TITLE
Fix an overflow in SEE

### DIFF
--- a/src/searchUtil.h
+++ b/src/searchUtil.h
@@ -105,7 +105,7 @@ inline bool see(Position &pos, int threshold, Move move) {
             continue;
         }
 
-        while (!attackers[stm] && stages[stm] < KING + 1) {
+        while (!attackers[stm] && stages[stm] < KING) {
             stage = PieceType(++stages[stm]);
             attackers[stm] |= getAttacks(stages[stm], to, blockers, !stm) & pos.getPieces(stm, stage) & blockers;
         }


### PR DESCRIPTION
If the stage is King and incremented by one, the stage would overflow leading to reading from bitboards that, in this context, are nonsensical

Passed Non-Regr:
Elo   | 29.49 +- 12.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 1358 W: 384 L: 269 D: 705
Penta | [8, 136, 293, 217, 25]
https://aytchell.eu.pythonanywhere.com/test/710/

bench 7874387