### PR TITLE
Display wdl calculate with a WDL head during search

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -70,6 +70,7 @@ class SearchState {
 public:
 
     void clearHistory();
+    std::string outputWDL(Position &pos);
     int startSearch(Position &pos, SearchTime &st, int maxDepth, Move &bestMove = emptyMove);
     int iterativeDeepening(Position  &pos, SearchTime &st, int maxDepth, [[maybe_unused]] Move &bestMove);
     int aspirationWindow(int prevScore, Position &pos, SearchInfo &si, int depth);


### PR DESCRIPTION
Non regr VSTC:
Elo   | 0.50 +- 3.34 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=4MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 20828 W: 5248 L: 5218 D: 10362
Penta | [262, 2315, 5261, 2283, 293]
https://aytchell.eu.pythonanywhere.com/test/713/

bench 8493466