### PR TITLE
Utilize some register juggling for a speedup

### DIFF
--- a/src/nnue.h
+++ b/src/nnue.h
@@ -236,6 +236,16 @@ inline void refreshSingle(Net* net, int offset, int bsq, int16_t* accum) {
         vec_storeu((vec_t *)(accum + idx + I16_PER_REG * i), acc[i]);  
 }
 
+template<Color C> 
+inline void refreshSingle(Net* net, int offset, vec_t* acc) {
+    vec_t w  [NUM_REGS];
+
+    net->loadWeightsVecs<C>(w, offset);
+
+    for (int i = 0; i < NUM_REGS; i++)
+        acc[i] = vec_add_epi16(acc[i], w[i]);
+}
+
 template<Color ON_COLOR, Color OFF_COLOR>
 inline void Net::addSubSingle(int sq, int onOffset, int offOffset) {
     int idx = sq * MINI_ACC_SIZE * 2;
@@ -332,6 +342,13 @@ inline void Net::addSub(Position& pos, uint64_t cleanBitboard, uint64_t white, i
     memcpy(&t[refreshSq * MINI_ACC_SIZE * 2                ], &bias0[biasIndex + MINI_ACC_SIZE * !RPC], MINI_ACC_SIZE * sizeof(int16_t));
     memcpy(&t[refreshSq * MINI_ACC_SIZE * 2 + MINI_ACC_SIZE], &bias0[biasIndex + MINI_ACC_SIZE *  RPC], MINI_ACC_SIZE * sizeof(int16_t));
 
+    int idx = refreshSq * MINI_ACC_SIZE * 2;
+
+    vec_t refreshAccs[NUM_REGS];
+
+    for (int i = 0; i < NUM_REGS; i++)
+        refreshAccs[i] = vec_loadu((vec_t *)(t + idx + I16_PER_REG * i));
+
     while (w) {
         int sq   = popLSB(w);
         Piece pc = pos.pieceOn(sq);
@@ -340,7 +357,7 @@ inline void Net::addSub(Position& pos, uint64_t cleanBitboard, uint64_t white, i
         int offOffset     = index_new<WHITE, WHITE, OFF_COLOR>(pc, sq, offPiece, offSquare);
         int refreshOffset = index_new<WHITE, WHITE>(refreshPc, refreshSq, pc, sq);
 
-        refreshSingle<WHITE>(this, refreshOffset, refreshSq, t);
+        refreshSingle<WHITE>(this, refreshOffset, refreshAccs);
 
         addSubSingle<ON_COLOR, OFF_COLOR>(sq, onOffset, offOffset);
     }
@@ -353,10 +370,13 @@ inline void Net::addSub(Position& pos, uint64_t cleanBitboard, uint64_t white, i
         int offOffset     = index_new<WHITE, BLACK, OFF_COLOR>(pc, sq, offPiece, offSquare);
         int refreshOffset = index_new<WHITE, BLACK>(refreshPc, refreshSq, pc, sq);
 
-        refreshSingle<BLACK>(this, refreshOffset, refreshSq, t);
+        refreshSingle<BLACK>(this, refreshOffset, refreshAccs);
 
         addSubSingle<ON_COLOR, OFF_COLOR>(sq, onOffset, offOffset);
     }
+
+    for (int i = 0; i < NUM_REGS; i++)
+        vec_storeu((vec_t *)(t + idx + I16_PER_REG * i), refreshAccs[i]);  
 
     accumulator = accumulatorStack[++accumulatorHead];
 }
@@ -375,6 +395,17 @@ inline void Net::addSubSub(Position& pos, uint64_t cleanBitboard, uint64_t white
     memcpy(&t[refreshSq * MINI_ACC_SIZE * 2                ], &bias0[biasIndex + MINI_ACC_SIZE * !RPC], MINI_ACC_SIZE * sizeof(int16_t));
     memcpy(&t[refreshSq * MINI_ACC_SIZE * 2 + MINI_ACC_SIZE], &bias0[biasIndex + MINI_ACC_SIZE *  RPC], MINI_ACC_SIZE * sizeof(int16_t));
 
+    int idx = refreshSq * MINI_ACC_SIZE * 2;
+
+
+     //  Last time checking (at num regs == 4) this function used 12 regs in total, 
+     //  this may be a slowdown if num regs grows beyond that.
+
+    vec_t refreshAccs[NUM_REGS];
+
+    for (int i = 0; i < NUM_REGS; i++)
+        refreshAccs[i] = vec_loadu((vec_t *)(t + idx + I16_PER_REG * i));
+
     while (w) {
         int sq   = popLSB(w);
         Piece pc = pos.pieceOn(sq);
@@ -384,7 +415,7 @@ inline void Net::addSubSub(Position& pos, uint64_t cleanBitboard, uint64_t white
         int capOffset     = index_new<WHITE, WHITE, CAP_COLOR>(pc, sq, capPiece,     capSq);
         int refreshOffset = index_new<WHITE, WHITE>(refreshPc, refreshSq, pc, sq);
 
-        refreshSingle<WHITE>(this, refreshOffset, refreshSq, t);
+        refreshSingle<WHITE>(this, refreshOffset, refreshAccs);
     
         addSubSubSingle<ON_COLOR, OFF_COLOR, CAP_COLOR>(sq, onOffset, offOffset, capOffset);
     }
@@ -398,10 +429,13 @@ inline void Net::addSubSub(Position& pos, uint64_t cleanBitboard, uint64_t white
         int capOffset = index_new<WHITE, BLACK, CAP_COLOR>(pc, sq, capPiece,     capSq);
         int refreshOffset = index_new<WHITE, BLACK>(refreshPc, refreshSq, pc, sq);
 
-        refreshSingle<BLACK>(this, refreshOffset, refreshSq, t);
+        refreshSingle<BLACK>(this, refreshOffset, refreshAccs);
 
         addSubSubSingle<ON_COLOR, OFF_COLOR, CAP_COLOR>(sq, onOffset, offOffset, capOffset);
     }
+
+    for (int i = 0; i < NUM_REGS; i++)
+        vec_storeu((vec_t *)(t + idx + I16_PER_REG * i), refreshAccs[i]);  
 
     accumulator = accumulatorStack[++accumulatorHead];
 }


### PR DESCRIPTION
similar to whats described here: https://cosmo.tardis.ac/files/2024-06-01-nnue.html

as described in the comment this may not be a speedup in this form when increasing mini acc size or using sse

No functional change:
Results of juggling vs master (25000 nodes, 1t, 16MB, UHO_Lichess_4852_v1.epd): Elo: -0.00 +/- 0.00, nElo: -nan +/- -nan
LOS: -nan %, DrawRatio: 100.00 %, PairsRatio: -nan Games: 1000, Wins: 242, Losses: 242, Draws: 516, Points: 500.0 (50.00 %) Ptnml(0-2): [0, 0, 500, 0, 0], WL/DD Ratio: 0.94

Passed VSTC:
Results of juggling vs master (2+0.02, 1t, 16MB, UHO_Lichess_4852_v1.epd): Elo: 22.49 +/- 8.91, nElo: 39.38 +/- 15.55
LOS: 100.00 %, DrawRatio: 47.34 %, PairsRatio: 1.54 Games: 1918, Wins: 543, Losses: 419, Draws: 956, Points: 1021.0 (53.23 %) Ptnml(0-2): [14, 185, 454, 275, 31], WL/DD Ratio: 0.83 LLR: 2.89 (100.0%) (-2.25, 2.89) [0.00, 5.00]

bench 8033433